### PR TITLE
feat: make beam-auth a standalone binary service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,11 @@ dependencies = [
  "bb8-redis",
  "beam-entity",
  "chrono",
+ "color-eyre",
+ "confique",
+ "dotenvy",
+ "eyre",
+ "http",
  "jsonwebtoken",
  "rand 0.10.0",
  "redis",
@@ -490,7 +495,9 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/beam-auth/.env.example
+++ b/beam-auth/.env.example
@@ -1,0 +1,6 @@
+BIND_ADDRESS=0.0.0.0:8001
+SERVER_URL=http://localhost:8001
+DATABASE_URL=postgres://beam:password@localhost:5432/beam
+JWT_SECRET=change_me_to_a_secure_random_string_at_least_32_chars_long
+REDIS_URL=redis://localhost:6379
+RUST_LOG=beam_auth=info

--- a/beam-auth/Cargo.toml
+++ b/beam-auth/Cargo.toml
@@ -4,9 +4,15 @@ version = "0.1.0"
 edition = "2024"
 license = "AGPL-3.0-only"
 publish = false
+default-run = "beam-auth"
+
+[[bin]]
+name = "beam-auth"
+path = "src/main.rs"
+required-features = ["server"]
 
 [features]
-default = []
+default = ["server"]
 utils = [
     "dep:argon2",
     "dep:async-trait",
@@ -30,6 +36,16 @@ server = [
 ]
 
 [dependencies]
+# Non-optional: always compiled (needed by config.rs, logging.rs, and main.rs)
+color-eyre = "0.6.5"
+confique = { workspace = true }
+dotenvy = "0.15.7"
+eyre = "0.6.12"
+http = { workspace = true }
+tokio = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["json", "env-filter"] }
+
+# Optional: feature-gated
 argon2 = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
 base64 = { version = "0.22.1", optional = true }

--- a/beam-auth/Containerfile
+++ b/beam-auth/Containerfile
@@ -1,0 +1,60 @@
+# ----------------------------------------------------
+# Stage 1: Setup chef image
+# ----------------------------------------------------
+FROM docker.io/rust:1.91-slim-trixie AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
+
+# ----------------------------------------------------
+# Stage 2: Create dependency recipe
+# ----------------------------------------------------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ----------------------------------------------------
+# Stage 3: Build Rust application
+# ----------------------------------------------------
+FROM chef AS builder
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libssl-dev \
+    pkg-config \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Cook dependencies first (cached layer)
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Build the application
+COPY . .
+RUN cargo build --release --package beam-auth
+
+# ----------------------------------------------------
+# Stage 4: Runtime image
+# ----------------------------------------------------
+FROM docker.io/debian:trixie-slim
+
+# Install minimal runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the binary from builder
+COPY --from=builder /app/target/release/beam-auth /usr/local/bin/beam-auth
+
+# Create non-root user
+RUN useradd -m -u 1000 -s /bin/bash appuser
+USER appuser
+
+# Expose port
+EXPOSE 8001/tcp
+
+# Run the binary
+CMD ["beam-auth"]

--- a/beam-auth/README.md
+++ b/beam-auth/README.md
@@ -1,0 +1,63 @@
+# Beam Auth
+
+A standalone authentication service for the Beam platform, providing user registration, login, session management, and JWT issuance.
+
+## Development
+
+- Copy `.env.example` to `.env` and modify as needed:
+
+    ```bash
+    cp .env.example .env
+    ```
+
+- Install some dependencies:
+
+    ```bash
+    cargo install cargo-watch
+    ```
+
+- Start other dependencies:
+
+    ```bash
+    podman compose -f compose.dependencies.yaml up -d
+    ```
+
+- Make sure you applied [migrations](../beam-migration/README.md)
+
+- Start development server:
+
+    ```bash
+    cargo watch -x run
+    ```
+
+### Build container image
+
+```bash
+# In root directory
+podman build -f beam-auth/Containerfile -t beam-auth .
+```
+
+## API Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/v1/health` | Health check — returns 200 OK when the service is running. |
+| `POST` | `/v1/auth/register` | Create a new account. Sets `session_id` cookie and returns a JWT. |
+| `POST` | `/v1/auth/login` | Authenticate with username/email and password. Sets `session_id` cookie and returns a JWT. |
+| `POST` | `/v1/auth/refresh` | Exchange a valid session cookie or `session_id` body field for a new JWT. |
+| `POST` | `/v1/auth/logout` | Invalidate the current session. Clears the `session_id` cookie. |
+
+## Architecture
+
+`beam-auth` is both a standalone binary service and a library crate with two feature flags:
+
+- **`utils`** — Core domain types, trait abstractions, and concrete implementations for user repositories, session stores, and the auth service.
+- **`server`** (implies `utils`) — Salvo HTTP handlers that wire the auth service into a router.
+
+Other services (e.g., `beam-stream`) depend on `beam-auth` as a library (with the `utils` feature) to perform local JWT verification without making network calls.
+
+### Session & Token Strategy
+
+- **Session**: A random 32-byte URL-safe Base64 ID stored in Redis/Valkey with a configurable TTL (default: 7 days).
+- **Access token**: A short-lived JWT (15 minutes) signed with HMAC-SHA256 containing the user ID (`sub`) and session ID (`sid`).
+- **Stream token**: A scoped JWT (6 hours) tied to a specific `stream_id`, used to authorize time-limited media access.

--- a/beam-auth/src/config.rs
+++ b/beam-auth/src/config.rs
@@ -1,0 +1,30 @@
+use confique::Config;
+
+/// Application configuration
+#[derive(Debug, Clone, Config)]
+pub struct ServerConfig {
+    #[config(env = "BIND_ADDRESS", default = "0.0.0.0:8001")]
+    pub bind_address: String,
+
+    #[config(env = "SERVER_URL", default = "http://localhost:8001")]
+    pub server_url: String,
+
+    #[config(
+        env = "DATABASE_URL",
+        default = "postgres://beam:password@localhost:5432/beam"
+    )]
+    pub database_url: String,
+
+    #[config(env = "REDIS_URL", default = "redis://localhost:6379")]
+    pub redis_url: String,
+
+    #[config(env = "JWT_SECRET")]
+    pub jwt_secret: String,
+}
+
+impl ServerConfig {
+    /// Load configuration from environment variables
+    pub fn load_and_validate() -> Result<Self, confique::Error> {
+        Self::builder().env().load()
+    }
+}

--- a/beam-auth/src/lib.rs
+++ b/beam-auth/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod config;
+pub mod logging;
+
 #[cfg(feature = "utils")]
 pub mod utils;
 

--- a/beam-auth/src/logging.rs
+++ b/beam-auth/src/logging.rs
@@ -1,0 +1,41 @@
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+#[inline]
+pub fn init_tracing() {
+    #[cfg(debug_assertions)]
+    {
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .pretty()
+                    .with_target(true)
+                    .with_file(true)
+                    .with_line_number(true)
+                    .with_thread_ids(true)
+                    .with_thread_names(true),
+            )
+            .with(
+                tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                    tracing_subscriber::EnvFilter::new("beam_auth=trace,salvo=debug")
+                }),
+            )
+            .init();
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_target(true)
+                    .with_level(true),
+            )
+            .with(
+                tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                    tracing_subscriber::EnvFilter::new("beam_auth=debug,salvo=debug")
+                }),
+            )
+            .init();
+    }
+}

--- a/beam-auth/src/main.rs
+++ b/beam-auth/src/main.rs
@@ -1,0 +1,99 @@
+use eyre::{Result, eyre};
+use http::Method;
+use salvo::cors::Cors;
+use salvo::prelude::*;
+use std::sync::Arc;
+use tracing::info;
+
+use beam_auth::config::ServerConfig;
+use beam_auth::server::auth_routes;
+use beam_auth::utils::repository::SqlUserRepository;
+use beam_auth::utils::service::{AuthService, LocalAuthService};
+use beam_auth::utils::session_store::RedisSessionStore;
+
+#[handler]
+async fn health_check(res: &mut Response) {
+    res.status_code(StatusCode::OK);
+    res.render(Text::Plain("OK"));
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    // Load environment variables from .env file if present
+    dotenvy::dotenv().ok();
+
+    // Initialize logging
+    beam_auth::logging::init_tracing();
+
+    info!("Starting beam-auth...");
+
+    // Load configuration
+    let config = ServerConfig::load_and_validate().map_err(|e| eyre!(e))?;
+
+    info!("Configuration loaded: {:?}", config);
+
+    // Connect to Database
+    info!("Connecting to database at {}", config.database_url);
+    let db = sea_orm::Database::connect(&config.database_url)
+        .await
+        .map_err(|e| eyre!("Failed to connect to database: {}", e))?;
+    info!("Connected to database");
+
+    // Connect to Redis
+    info!("Connecting to Redis at {}", config.redis_url);
+    let session_store = Arc::new(
+        RedisSessionStore::new(&config.redis_url)
+            .await
+            .map_err(|e| eyre!("Failed to connect to Redis: {}", e))?,
+    );
+    info!("Connected to Redis");
+
+    // Build services
+    let user_repo = Arc::new(SqlUserRepository::new(db));
+    let auth_service: Arc<dyn AuthService> = Arc::new(LocalAuthService::new(
+        user_repo,
+        session_store,
+        config.jwt_secret.clone(),
+    ));
+
+    // Build CORS handler
+    let cors = Cors::new()
+        .allow_origin(salvo::cors::AllowOrigin::mirror_request())
+        .allow_methods(vec![
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers(vec![
+            "authorization",
+            "content-type",
+            "accept",
+            "x-requested-with",
+        ])
+        .allow_credentials(true)
+        .max_age(3600)
+        .into_handler();
+
+    // Build API router
+    let router = Router::new()
+        .hoop(affix_state::inject(auth_service))
+        .push(
+            Router::with_path("v1")
+                .push(Router::with_path("health").get(health_check))
+                .push(Router::with_path("auth").push(auth_routes())),
+        );
+
+    let service = Service::new(router).hoop(cors);
+
+    info!("Binding to address: {}", &config.bind_address);
+    let acceptor = TcpListener::new(config.bind_address.clone()).bind().await;
+
+    info!("Server listening on {}", config.bind_address);
+
+    Server::new(acceptor).serve(service).await;
+
+    Ok(())
+}

--- a/beam-stream/Cargo.toml
+++ b/beam-stream/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 default-run = "beam-stream"
 
 [dependencies]
-beam-auth = { path = "../beam-auth", features = ["utils", "server"] }
+beam-auth = { path = "../beam-auth", features = ["utils"] }
 beam-entity = { path = "../beam-entity" }
 http = { workspace = true }
 async-graphql = { version = "7.0.17", features = [

--- a/beam-stream/src/routes/mod.rs
+++ b/beam-stream/src/routes/mod.rs
@@ -15,7 +15,7 @@ use beam_stream::state::AppState;
 
 /// Create the main API router with all routes
 pub fn create_router(state: AppState, schema: AppSchema) -> Router {
-    let auth_service: Arc<dyn AuthService> = Arc::clone(&state.services.auth);
+    let _auth_service: Arc<dyn AuthService> = Arc::clone(&state.services.auth);
 
     // Note: No authorization is done at the top-level here because only `graphql` is secured with auth the other endpoints are either public or require query params (i.e., presigned URLs)
     Router::new().hoop(affix_state::inject(state)).push(
@@ -23,7 +23,6 @@ pub fn create_router(state: AppState, schema: AppSchema) -> Router {
             .push(Router::with_path("health").get(health_check))
             .push(Router::with_path("stream/<id>/token").post(get_stream_token))
             .push(Router::with_path("stream/mp4/<id>").get(stream_mp4))
-            .push(Router::with_path("auth").push(auth::auth_routes()))
             .push(
                 Router::with_path("graphql")
                     .hoop(affix_state::inject(schema))

--- a/beam-stream/src/routes/mod.rs
+++ b/beam-stream/src/routes/mod.rs
@@ -4,19 +4,15 @@ pub mod stream;
 pub mod upload;
 
 use salvo::prelude::*;
-use std::sync::Arc;
 
 pub use health::*;
 pub use stream::*;
 
-use beam_auth::utils::service::AuthService;
 use beam_stream::graphql::AppSchema;
 use beam_stream::state::AppState;
 
 /// Create the main API router with all routes
 pub fn create_router(state: AppState, schema: AppSchema) -> Router {
-    let _auth_service: Arc<dyn AuthService> = Arc::clone(&state.services.auth);
-
     // Note: No authorization is done at the top-level here because only `graphql` is secured with auth the other endpoints are either public or require query params (i.e., presigned URLs)
     Router::new().hoop(affix_state::inject(state)).push(
         Router::with_path("v1")

--- a/beam-stream/src/state.rs
+++ b/beam-stream/src/state.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use beam_auth::utils::{
     repository::SqlUserRepository,
     service::{AuthService, LocalAuthService},
-    session_store::{RedisSessionStore, SessionStore},
+    session_store::RedisSessionStore,
 };
 
 use crate::{
@@ -69,7 +69,6 @@ impl AppContext {
 #[derive(Debug)]
 pub struct AppServices {
     pub auth: Arc<dyn AuthService>,
-    pub session_store: Arc<dyn SessionStore>,
     pub hash: Arc<dyn HashService>,
     pub library: Arc<dyn LibraryService>,
     pub metadata: Arc<dyn MetadataService>,
@@ -110,13 +109,12 @@ impl AppServices {
 
         let auth_service = Arc::new(LocalAuthService::new(
             user_repo,
-            session_store.clone(),
+            session_store,
             config.jwt_secret.clone(),
         ));
 
         Self {
             auth: auth_service,
-            session_store,
             hash: hash_service.clone() as Arc<dyn HashService>,
             library: Arc::new(LocalLibraryService::new(
                 library_repo,

--- a/compose.beam.yaml
+++ b/compose.beam.yaml
@@ -1,4 +1,29 @@
 services:
+  auth:
+    build:
+      context: .
+      dockerfile: beam-auth/Containerfile
+    environment:
+      BIND_ADDRESS: ${AUTH_BIND_ADDRESS:-0.0.0.0:8001}
+      SERVER_URL: ${AUTH_SERVER_URL:-http://localhost:8001}
+      DATABASE_URL: ${DATABASE_URL:-postgres://beam:password@postgres:5432/beam}
+      RUST_LOG: ${RUST_LOG:-beam_auth=info}
+      REDIS_URL: ${REDIS_URL:-redis://valkey:6379}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is not set or is empty}
+    ports:
+      - "${AUTH_HOST_PORT:-8001}:8001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/v1/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
+
   stream:
     build:
       context: .


### PR DESCRIPTION
beam-auth is now a first-class deployable service alongside beam-stream. Auth HTTP endpoints are removed from beam-stream's router and served exclusively by the new beam-auth process.

- Add src/main.rs, config.rs, logging.rs to boot a Salvo server with full DB + Redis + JWT wiring (mirrors beam-stream startup sequence)
- Add Containerfile (4-stage, no FFmpeg) targeting port 8001
- Add .env.example and rewrite README.md for standalone usage
- Update Cargo.toml: [[bin]], default = ["server"], non-optional deps (color-eyre, confique, dotenvy, eyre, http, tokio, tracing-subscriber)
- Expose config/logging modules unconditionally from lib.rs
- Add auth service to compose.beam.yaml with healthcheck on /v1/health
- Remove auth route mount from beam-stream/src/routes/mod.rs