### PR TITLE
fix: make all container images build successfully

### DIFF
--- a/beam-auth/Containerfile
+++ b/beam-auth/Containerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
 
 # Cook dependencies first (cached layer)
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json --bin beam-auth
 
 # Build the application
 COPY . .

--- a/beam-stream/Containerfile
+++ b/beam-stream/Containerfile
@@ -68,6 +68,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl \
     clang libclang-dev pkg-config \
+    protobuf-compiler \
     libx264-dev libx265-dev libvpx-dev \
     libopus-dev libass-dev libfreetype-dev libfontconfig-dev \
     libfribidi-dev libogg-dev libssl-dev \
@@ -83,6 +84,7 @@ ENV PATH=/opt/ffmpeg/bin:$PATH
 
 # Copy the dependency recipe
 COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json --bin beam-stream
 
 # Build application
 COPY . .

--- a/beam-stream/src/bin/export_schema.rs
+++ b/beam-stream/src/bin/export_schema.rs
@@ -1,39 +1,25 @@
 //! Export GraphQL schema to a file for code generation
 
-use beam_stream::config::ServerConfig;
-use beam_stream::graphql::create_schema;
-use beam_stream::state::AppServices;
-use beam_stream::state::AppState;
+use async_graphql::Schema;
+use beam_stream::graphql::schema::{MutationRoot, QueryRoot, SubscriptionRoot};
 use eyre::Result;
 use std::fs;
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    color_eyre::install()?;
-    dotenvy::dotenv().ok();
+fn main() -> Result<()> {
+    // Build schema from type definitions only - no runtime services needed
+    let schema = Schema::build(
+        QueryRoot::default(),
+        MutationRoot::default(),
+        SubscriptionRoot::default(),
+    )
+    .finish();
 
-    // Load configuration (or use defaults)
-    let config = ServerConfig::load_and_validate()?;
-
-    // Connect to database (needed for schema creation even if not used)
-    // We can use the real DB since we expect it to be running in dev environment
-    let db = sea_orm::Database::connect(&config.database_url).await?;
-
-    // Create Services
-    let services = AppServices::new(&config, db).await?;
-    let state = AppState::new(config.clone(), services);
-
-    // Create the GraphQL schema
-    let schema = create_schema(state);
-
-    // Export as SDL
     let sdl = schema.sdl();
 
-    // Write to beam-stream directory
     let output_path = "schema.graphql";
-    fs::write(output_path, sdl)?;
+    fs::write(output_path, &sdl)?;
 
-    println!("GraphQL schema exported to: beam-stream/{output_path}");
+    println!("GraphQL schema exported to: {output_path}");
 
     Ok(())
 }

--- a/beam-web/Containerfile
+++ b/beam-web/Containerfile
@@ -1,4 +1,92 @@
 # ----------------------------------------------------
+# Stage 1: Build FFmpeg 8.0 from source
+# ----------------------------------------------------
+FROM docker.io/debian:trixie-slim AS ffmpeg-builder
+
+# Install all build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential pkg-config yasm nasm wget ca-certificates \
+    libx264-dev libx265-dev libvpx-dev \
+    libopus-dev libass-dev libfreetype-dev libfontconfig-dev \
+    libfribidi-dev libogg-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/ffmpeg
+
+RUN wget -q https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz && \
+    tar xf ffmpeg-8.0.tar.xz && \
+    cd ffmpeg-8.0 && \
+    ./configure \
+    --prefix=/opt/ffmpeg \
+    --disable-debug \
+    --disable-doc \
+    --disable-ffplay \
+    --enable-shared \
+    --disable-static \
+    --enable-gpl \
+    --enable-version3 \
+    --enable-fontconfig \
+    --enable-libass \
+    --enable-libfontconfig \
+    --enable-libfreetype \
+    --enable-libfribidi \
+    --enable-libopus \
+    --enable-libvpx \
+    --enable-libx264 \
+    --enable-libx265 \
+    --enable-openssl \
+    --enable-small \
+    --extra-cflags="-I/opt/ffmpeg/include" \
+    --extra-ldflags="-L/opt/ffmpeg/lib" \
+    --extra-libs=-lpthread \
+    --extra-libs=-lm && \
+    make -j$(nproc) && \
+    make install
+
+# ----------------------------------------------------
+# Chef: Setup chef image
+# ----------------------------------------------------
+FROM docker.io/rust:1.91-slim-trixie AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
+
+# ----------------------------------------------------
+# Planner: Create dependency recipe
+# ----------------------------------------------------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ----------------------------------------------------
+# Schema: Generate GraphQL schema from Rust types
+# ----------------------------------------------------
+FROM chef AS schema-builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    clang libclang-dev pkg-config \
+    protobuf-compiler \
+    libx264-dev libx265-dev libvpx-dev \
+    libopus-dev libass-dev libfreetype-dev libfontconfig-dev \
+    libfribidi-dev libogg-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ffmpeg-builder /opt/ffmpeg /opt/ffmpeg
+
+ENV PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+ENV LD_LIBRARY_PATH=/opt/ffmpeg/lib:/usr/lib/aarch64-linux-gnu:/usr/lib/x86_64-linux-gnu
+ENV PATH=/opt/ffmpeg/bin:$PATH
+
+# Cook dependencies for the schema export binary
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --recipe-path recipe.json --bin export_schema
+
+COPY . .
+RUN cargo build --bin export_schema
+RUN cd beam-stream && ../target/debug/export_schema
+
+# ----------------------------------------------------
 # Build: Build the application using Bun
 # ----------------------------------------------------
 FROM docker.io/oven/bun:1.3-debian AS builder
@@ -9,17 +97,17 @@ ARG C_STREAM_SERVER_URL=http://localhost:8000
 
 WORKDIR /app
 
-# Copy package files and lockfile for beam-web
-COPY beam-web/package.json beam-web/bun.lock ./beam-web/
+# Copy workspace root package files and all workspace member package.json files for dependency install
+COPY package.json bun.lock ./
+COPY beam-web/package.json ./beam-web/
+COPY beam-docs/package.json ./beam-docs/
 
-# Install dependencies
-WORKDIR /app/beam-web
+# Install dependencies from workspace root
 RUN bun install --frozen-lockfile
 
-# Copy beam-web source and the pre-generated schema from beam-stream
-WORKDIR /app
+# Copy beam-web source and the generated schema from schema-builder
 COPY beam-web ./beam-web
-COPY beam-stream/schema.graphql ./beam-stream/schema.graphql
+COPY --from=schema-builder /app/beam-stream/schema.graphql ./beam-stream/schema.graphql
 
 # Generate TypeScript types from the schema
 WORKDIR /app/beam-web
@@ -50,14 +138,14 @@ COPY <<EOF /etc/caddy/Caddyfile
     encode gzip zstd
     file_server
     try_files {path} /index.html
-    
+
     header {
         # Security headers
         X-Content-Type-Options "nosniff"
         X-Frame-Options "DENY"
         Referrer-Policy "strict-origin-when-cross-origin"
     }
-    
+
     # Cache static assets
     @static {
         path *.js *.css *.woff *.woff2 *.ttf *.eot *.ico *.png *.jpg *.jpeg *.gif *.svg *.webp

--- a/beam-web/codegen.ts
+++ b/beam-web/codegen.ts
@@ -21,6 +21,11 @@ const config: CodegenConfig = {
 				},
 				// Use `unknown` instead of `any` for unconfigured scalars
 				defaultScalarType: "unknown",
+				// Map known scalars to concrete TypeScript types
+				scalars: {
+					DateTime: "string",
+					Decimal: "string",
+				},
 				// Apollo Client always includes `__typename` fields
 				nonOptionalTypename: true,
 				// Apollo Client doesn't add the `__typename` field to root types so

--- a/beam-web/src/routes/admin.tsx
+++ b/beam-web/src/routes/admin.tsx
@@ -14,17 +14,15 @@ import { useAuth } from "../hooks/auth";
 
 const GET_ADMIN_LOGS = gql`
   query GetAdminLogs($limit: Int, $offset: Int) {
-    admin {
-      logs(limit: $limit, offset: $offset) {
-        id
-        level
-        category
-        message
-        details
-        createdAt
-      }
-      logCount
+    logs(limit: $limit, offset: $offset) {
+      id
+      level
+      category
+      message
+      details
+      createdAt
     }
+    logCount
   }
 `;
 
@@ -38,10 +36,8 @@ interface AdminLogEntry {
 }
 
 interface AdminQueryResult {
-	admin: {
-		logs: AdminLogEntry[];
-		logCount: number;
-	};
+	logs: AdminLogEntry[];
+	logCount: number;
 }
 
 const PAGE_SIZE = 50;
@@ -117,8 +113,8 @@ function AdminPage() {
 		},
 	);
 
-	const logs = data?.admin?.logs ?? [];
-	const totalCount = data?.admin?.logCount ?? 0;
+	const logs = data?.logs ?? [];
+	const totalCount = data?.logCount ?? 0;
 	const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
 
 	return (

--- a/beam-web/src/routes/explore.tsx
+++ b/beam-web/src/routes/explore.tsx
@@ -28,22 +28,21 @@ const SEARCH_MEDIA: TypedDocumentNode<
 		$query: String
 		$minRating: Int
 	) {
-		media {
-			search(
-				first: $first
-				after: $after
-				last: $last
-				before: $before
-				sortBy: $sortBy
-				sortOrder: $sortOrder
-				mediaType: $mediaType
-				genre: $genre
-				year: $year
-				yearFrom: $yearFrom
-				yearTo: $yearTo
-				query: $query
-				minRating: $minRating
-			) {
+		search(
+			first: $first
+			after: $after
+			last: $last
+			before: $before
+			sortBy: $sortBy
+			sortOrder: $sortOrder
+			mediaType: $mediaType
+			genre: $genre
+			year: $year
+			yearFrom: $yearFrom
+			yearTo: $yearTo
+			query: $query
+			minRating: $minRating
+		) {
 				edges {
 					cursor
 					node {
@@ -85,7 +84,6 @@ const SEARCH_MEDIA: TypedDocumentNode<
 					startCursor
 					endCursor
 				}
-			}
 		}
 	}
 `;

--- a/beam-web/src/routes/index.tsx
+++ b/beam-web/src/routes/index.tsx
@@ -14,16 +14,14 @@ import type { QueryRoot } from "../gql";
 
 const GET_LIBRARIES = gql`
   query GetLibraries {
-    library {
-      libraries {
-        id
-        name
-        description
-        size
-        lastScanStartedAt
-        lastScanFinishedAt
-        lastScanFileCount
-      }
+    libraries {
+      id
+      name
+      description
+      size
+      lastScanStartedAt
+      lastScanFinishedAt
+      lastScanFileCount
     }
   }
 `;
@@ -34,7 +32,7 @@ export const Route = createFileRoute("/")({
 
 function DashboardPage() {
 	const { data, loading } = useQuery<QueryRoot>(GET_LIBRARIES);
-	const libraries = data?.library?.libraries ?? [];
+	const libraries = data?.libraries ?? [];
 	const totalFiles = libraries.reduce((sum, lib) => sum + lib.size, 0);
 
 	return (

--- a/beam-web/src/routes/libraries.$id.tsx
+++ b/beam-web/src/routes/libraries.$id.tsx
@@ -24,7 +24,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type {
 	LibraryFile,
-	LibraryMutationScanLibraryArgs,
 	MutationRoot,
 	QueryRoot,
 } from "../gql";
@@ -32,38 +31,34 @@ import { FileContentType, FileIndexStatus } from "../gql";
 
 const GET_LIBRARY_WITH_FILES = gql`
   query GetLibraryWithFiles($id: ID!, $libraryId: ID!) {
-    library {
-      libraryById(id: $id) {
-        id
-        name
-        description
-        size
-        lastScanStartedAt
-        lastScanFinishedAt
-        lastScanFileCount
-      }
-      libraryFiles(libraryId: $libraryId) {
-        id
-        libraryId
-        path
-        sizeBytes
-        mimeType
-        durationSecs
-        containerFormat
-        status
-        contentType
-        scannedAt
-        updatedAt
-      }
+    libraryById(id: $id) {
+      id
+      name
+      description
+      size
+      lastScanStartedAt
+      lastScanFinishedAt
+      lastScanFileCount
+    }
+    libraryFiles(libraryId: $libraryId) {
+      id
+      libraryId
+      path
+      sizeBytes
+      mimeType
+      durationSecs
+      containerFormat
+      status
+      contentType
+      scannedAt
+      updatedAt
     }
   }
 `;
 
 const SCAN_LIBRARY = gql`
   mutation ScanLibrary($id: ID!) {
-    library {
-      scanLibrary(id: $id)
-    }
+    scanLibrary(id: $id)
   }
 `;
 
@@ -199,10 +194,9 @@ function LibraryDetailPage() {
 		GET_LIBRARY_WITH_FILES,
 		{ variables: { id, libraryId: id } },
 	);
-	const [scanLibrary] = useMutation<
-		MutationRoot,
-		LibraryMutationScanLibraryArgs
-	>(SCAN_LIBRARY);
+	const [scanLibrary] = useMutation<MutationRoot, { id: string }>(
+		SCAN_LIBRARY,
+	);
 
 	const [scanning, setScanning] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
@@ -233,8 +227,8 @@ function LibraryDetailPage() {
 		}
 	};
 
-	const files = data?.library?.libraryFiles ?? [];
-	const library = data?.library?.libraryById;
+	const files = data?.libraryFiles ?? [];
+	const library = data?.libraryById;
 
 	// Filter and sort files
 	const filteredFiles = useMemo(() => {

--- a/beam-web/src/routes/libraries.$id.tsx
+++ b/beam-web/src/routes/libraries.$id.tsx
@@ -22,11 +22,7 @@ import {
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import type {
-	LibraryFile,
-	MutationRoot,
-	QueryRoot,
-} from "../gql";
+import type { LibraryFile, MutationRoot, QueryRoot } from "../gql";
 import { FileContentType, FileIndexStatus } from "../gql";
 
 const GET_LIBRARY_WITH_FILES = gql`
@@ -194,9 +190,7 @@ function LibraryDetailPage() {
 		GET_LIBRARY_WITH_FILES,
 		{ variables: { id, libraryId: id } },
 	);
-	const [scanLibrary] = useMutation<MutationRoot, { id: string }>(
-		SCAN_LIBRARY,
-	);
+	const [scanLibrary] = useMutation<MutationRoot, { id: string }>(SCAN_LIBRARY);
 
 	const [scanning, setScanning] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");

--- a/beam-web/src/routes/libraries.tsx
+++ b/beam-web/src/routes/libraries.tsx
@@ -117,9 +117,7 @@ function LibrariesPage() {
 		MutationRoot,
 		{ name: string; rootPath: string }
 	>(CREATE_LIBRARY);
-	const [scanLibrary] = useMutation<MutationRoot, { id: string }>(
-		SCAN_LIBRARY,
-	);
+	const [scanLibrary] = useMutation<MutationRoot, { id: string }>(SCAN_LIBRARY);
 	const [deleteLibrary] = useMutation<MutationRoot, { id: string }>(
 		DELETE_LIBRARY,
 	);

--- a/beam-web/src/routes/libraries.tsx
+++ b/beam-web/src/routes/libraries.tsx
@@ -16,60 +16,45 @@ import { useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import type {
-	Library,
-	LibraryMutationCreateLibraryArgs,
-	LibraryMutationDeleteLibraryArgs,
-	LibraryMutationScanLibraryArgs,
-	MutationRoot,
-	QueryRoot,
-} from "../gql";
+import type { Library, MutationRoot, QueryRoot } from "../gql";
 
 const GET_LIBRARIES = gql`
   query GetLibraries {
-    library {
-      libraries {
-        id
-        name
-        description
-        size
-        lastScanStartedAt
-        lastScanFinishedAt
-        lastScanFileCount
-      }
+    libraries {
+      id
+      name
+      description
+      size
+      lastScanStartedAt
+      lastScanFinishedAt
+      lastScanFileCount
     }
   }
 `;
 
 const CREATE_LIBRARY = gql`
   mutation CreateLibrary($name: String!, $rootPath: String!) {
-    library {
-      createLibrary(name: $name, rootPath: $rootPath) {
-        id
-        name
-        description
-        size
-        lastScanStartedAt
-        lastScanFinishedAt
-        lastScanFileCount
-      }
+    createLibrary(name: $name, rootPath: $rootPath) {
+      id
+      name
+      description
+      size
+      lastScanStartedAt
+      lastScanFinishedAt
+      lastScanFileCount
     }
   }
 `;
 
 const SCAN_LIBRARY = gql`
   mutation ScanLibrary($id: ID!) {
-    library {
-      scanLibrary(id: $id)
-    }
+    scanLibrary(id: $id)
   }
 `;
 
 const DELETE_LIBRARY = gql`
   mutation DeleteLibrary($id: ID!) {
-    library {
-      deleteLibrary(id: $id)
-    }
+    deleteLibrary(id: $id)
   }
 `;
 
@@ -130,16 +115,14 @@ function LibrariesPage() {
 	const { data, loading, error, refetch } = useQuery<QueryRoot>(GET_LIBRARIES);
 	const [createLibrary, { loading: creating }] = useMutation<
 		MutationRoot,
-		LibraryMutationCreateLibraryArgs
+		{ name: string; rootPath: string }
 	>(CREATE_LIBRARY);
-	const [scanLibrary] = useMutation<
-		MutationRoot,
-		LibraryMutationScanLibraryArgs
-	>(SCAN_LIBRARY);
-	const [deleteLibrary] = useMutation<
-		MutationRoot,
-		LibraryMutationDeleteLibraryArgs
-	>(DELETE_LIBRARY);
+	const [scanLibrary] = useMutation<MutationRoot, { id: string }>(
+		SCAN_LIBRARY,
+	);
+	const [deleteLibrary] = useMutation<MutationRoot, { id: string }>(
+		DELETE_LIBRARY,
+	);
 
 	const [name, setName] = useState("");
 	const [rootPath, setRootPath] = useState("");
@@ -221,7 +204,7 @@ function LibrariesPage() {
 		);
 	}
 
-	const libraries = data?.library?.libraries ?? [];
+	const libraries = data?.libraries ?? [];
 
 	return (
 		<div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950">

--- a/beam-web/src/routes/media.$id.tsx
+++ b/beam-web/src/routes/media.$id.tsx
@@ -13,14 +13,13 @@ const GET_METADATA_BY_ID: TypedDocumentNode<
 	GetMediaMetadataByIdQueryVariables
 > = gql`
   	query GetMediaMetadataById($mediaId: ID!) {
-		media {
-			metadata(id: $mediaId) {
+		metadata(id: $mediaId) {
 			__typename
 			... on ShowMetadata {
 				title {
-				original
-				localized
-				alternatives
+					original
+					localized
+					alternatives
 				}
 				description
 				year
@@ -107,8 +106,8 @@ const GET_METADATA_BY_ID: TypedDocumentNode<
 						maxRate
 						bitRate
 						resolution {
-						width
-						height
+							width
+							height
 						}
 						frameRate
 					}
@@ -129,7 +128,6 @@ const GET_METADATA_BY_ID: TypedDocumentNode<
 						isForced
 					}
 				}
-			}
 			}
 		}
 	}
@@ -171,9 +169,9 @@ function RouteComponent() {
 	return (
 		<div className="container mx-auto p-4">
 			<h1 className="text-2xl font-bold mb-4">
-				{data.media.metadata?.title.original}
+				{data.metadata?.title.original}
 			</h1>
-			<p className="mb-4">{data.media.metadata?.description}</p>
+			<p className="mb-4">{data.metadata?.description}</p>
 			{/* Watch Link */}
 			<a
 				href={streamLink}


### PR DESCRIPTION
- beam-auth/Containerfile: scope cargo-chef cook to --bin beam-auth to avoid pulling FFmpeg build deps from beam-stream
- beam-stream/Containerfile: add missing cargo chef cook step; add protobuf-compiler for beam-index proto compilation; scope cook to --bin beam-stream
- beam-web/Containerfile: fix bun workspace install (root bun.lock, include beam-docs); add Rust+FFmpeg stages to generate schema.graphql at build time instead of requiring it pre-committed
- beam-stream/src/bin/export_schema.rs: remove infrastructure dependency (DB, Redis) — generate SDL from type definitions alone
- beam-web/codegen.ts: add DateTime and Decimal scalar type mappings
- beam-web/src/routes/*: fix GraphQL queries to use flat root fields matching the MergedObject schema (remove library/admin/media namespace wrappers); update TypeScript data access patterns accordingly