### PR TITLE
fix(beam-stream): replace hardcoded video/cache paths in stream_mp4

### DIFF
--- a/beam-stream/src/graphql/auth_tests.rs
+++ b/beam-stream/src/graphql/auth_tests.rs
@@ -76,6 +76,12 @@ mod tests {
         async fn delete_library(&self, _library_id: String) -> Result<bool, LibraryError> {
             unimplemented!("not called in auth tests")
         }
+        async fn get_file_by_id(
+            &self,
+            _file_id: String,
+        ) -> Result<Option<crate::models::LibraryFile>, LibraryError> {
+            unimplemented!("not called in auth tests")
+        }
     }
 
     #[derive(Debug)]

--- a/beam-stream/src/services/library.rs
+++ b/beam-stream/src/services/library.rs
@@ -25,6 +25,9 @@ pub trait LibraryService: Send + Sync + std::fmt::Debug {
     async fn get_library_files(&self, library_id: String)
     -> Result<Vec<LibraryFile>, LibraryError>;
 
+    /// Get a single file by its ID
+    async fn get_file_by_id(&self, file_id: String) -> Result<Option<LibraryFile>, LibraryError>;
+
     /// Create a new library
     async fn create_library(
         &self,
@@ -134,6 +137,12 @@ impl LibraryService for LocalLibraryService {
 
         let files = self.file_repo.find_all_by_library(lib_uuid).await?;
         Ok(files.into_iter().map(LibraryFile::from).collect())
+    }
+
+    async fn get_file_by_id(&self, file_id: String) -> Result<Option<LibraryFile>, LibraryError> {
+        let file_uuid = Uuid::parse_str(&file_id).map_err(|_| LibraryError::InvalidId)?;
+        let file = self.file_repo.find_by_id(file_uuid).await?;
+        Ok(file.map(LibraryFile::from))
     }
 
     async fn create_library(

--- a/beam-stream/src/services/metadata_tests.rs
+++ b/beam-stream/src/services/metadata_tests.rs
@@ -251,6 +251,10 @@ mod tests {
                 .cloned())
         }
 
+        async fn find_by_id(&self, id: Uuid) -> Result<Option<MediaFile>, DbErr> {
+            Ok(self.files.lock().unwrap().get(&id).cloned())
+        }
+
         async fn find_all_by_library(&self, library_id: Uuid) -> Result<Vec<MediaFile>, DbErr> {
             Ok(self
                 .files


### PR DESCRIPTION
Add FileRepository::find_by_id, LibraryService::get_file_by_id, and use them in stream_mp4 to resolve the actual file path from the DB and derive the cache path from config.cache_dir instead of hardcoded strings.