### PR TITLE
refactor(beam-stream): abstract FS ops in create_library behind PathValidator trait

### DIFF
--- a/beam-stream/src/services/library_tests.rs
+++ b/beam-stream/src/services/library_tests.rs
@@ -2,13 +2,12 @@
 mod tests {
     use crate::repositories::file::MockFileRepository;
     use crate::repositories::library::MockLibraryRepository;
-    use crate::services::library::LocalLibraryService;
+    use crate::services::library::{InMemoryPathValidator, LocalLibraryService};
     use crate::services::notification::InMemoryNotificationService;
     use beam_index::models::domain::Library as DomainLibrary;
     use beam_index::services::index::MockIndexService;
     use std::path::PathBuf;
     use std::sync::Arc;
-    use tempfile::TempDir;
     use uuid::Uuid;
 
     fn make_service(
@@ -20,9 +19,10 @@ mod tests {
         LocalLibraryService::new(
             Arc::new(mock_library_repo),
             Arc::new(mock_file_repo),
-            video_dir,
+            video_dir.clone(),
             Arc::new(InMemoryNotificationService::new()),
             Arc::new(mock_index_service),
+            Arc::new(InMemoryPathValidator::success(video_dir)),
         )
     }
 
@@ -32,8 +32,7 @@ mod tests {
 
         let mock_library_repo = MockLibraryRepository::new();
         let mock_file_repo = MockFileRepository::new();
-        let temp_dir = TempDir::new().unwrap();
-        let video_dir = temp_dir.path().to_path_buf();
+        let video_dir = PathBuf::from("/media/videos");
 
         let lib_id = Uuid::new_v4().to_string();
         let lib_id_clone = lib_id.clone();
@@ -58,8 +57,7 @@ mod tests {
 
         let mock_library_repo = MockLibraryRepository::new();
         let mock_file_repo = MockFileRepository::new();
-        let temp_dir = TempDir::new().unwrap();
-        let video_dir = temp_dir.path().to_path_buf();
+        let video_dir = PathBuf::from("/media/videos");
 
         let mut mock_index = MockIndexService::new();
         mock_index
@@ -79,8 +77,7 @@ mod tests {
 
         let mut mock_library_repo = MockLibraryRepository::new();
         let mock_file_repo = MockFileRepository::new();
-        let temp_dir = TempDir::new().unwrap();
-        let video_dir = temp_dir.path().to_path_buf();
+        let video_dir = PathBuf::from("/media/videos");
         let mock_index = MockIndexService::new();
 
         let lib_id = Uuid::new_v4();

--- a/beam-stream/src/state.rs
+++ b/beam-stream/src/state.rs
@@ -15,7 +15,7 @@ use crate::{
         GrpcIndexService,
         admin_log::{AdminLogService, LocalAdminLogService},
         hash::{HashConfig, HashService, LocalHashService},
-        library::{LibraryService, LocalLibraryService},
+        library::{LibraryService, LocalLibraryService, OsPathValidator},
         metadata::{DbMetadataService, MetadataService},
         notification::{LocalNotificationService, NotificationService},
         transcode::{LocalTranscodeService, TranscodeService},
@@ -140,6 +140,7 @@ impl AppServices {
                 config.video_dir.clone(),
                 notification_service.clone(),
                 index_service,
+                Arc::new(OsPathValidator),
             )),
             metadata: Arc::new(DbMetadataService::new(
                 movie_repo,


### PR DESCRIPTION
## Summary

- Introduces `PathValidator` trait to decouple `LocalLibraryService::create_library` from direct `std::fs::canonicalize` calls
- Adds `OsPathValidator` (production): encapsulates canonicalize + path-containment check logic
- Adds `InMemoryPathValidator` (test-utils): configurable success/failure variants, gated behind `#[cfg(any(test, feature = "test-utils"))]`
- Updates `LocalLibraryService::new()` to accept `Arc<dyn PathValidator>` and injects `OsPathValidator` in `state.rs`
- Removes `TempDir` dependency from existing library tests — no real filesystem needed

Closes td-6e75c9 | Unblocks td-698c0a (LibraryService unit test expansion)

## Test plan

- [x] All existing 22 tests pass (`cargo test -p beam-stream`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Verify `InMemoryPathValidator` error injection works in expanded tests (td-698c0a)