### PR TITLE
refactor(beam-stream): extract in-memory repository fakes into reusable test-utils modules

### DIFF
--- a/beam-index/src/repositories/file.rs
+++ b/beam-index/src/repositories/file.rs
@@ -200,3 +200,125 @@ impl FileRepository for SqlFileRepository {
         Ok(result.rows_affected)
     }
 }
+
+/// In-memory implementation for use in tests and test-utils consumers.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod in_memory {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    pub struct InMemoryFileRepository {
+        pub files: Mutex<HashMap<Uuid, MediaFile>>,
+    }
+
+    #[async_trait]
+    impl FileRepository for InMemoryFileRepository {
+        async fn find_by_id(&self, id: Uuid) -> Result<Option<MediaFile>, DbErr> {
+            Ok(self.files.lock().unwrap().get(&id).cloned())
+        }
+
+        async fn find_by_path(&self, path: &str) -> Result<Option<MediaFile>, DbErr> {
+            Ok(self
+                .files
+                .lock()
+                .unwrap()
+                .values()
+                .find(|f| f.path == Path::new(path))
+                .cloned())
+        }
+
+        async fn find_all_by_library(&self, library_id: Uuid) -> Result<Vec<MediaFile>, DbErr> {
+            Ok(self
+                .files
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|f| f.library_id == library_id)
+                .cloned()
+                .collect())
+        }
+
+        async fn find_by_movie_entry_id(
+            &self,
+            movie_entry_id: Uuid,
+        ) -> Result<Vec<MediaFile>, DbErr> {
+            use crate::models::domain::MediaFileContent;
+            Ok(self
+                .files
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|f| {
+                    matches!(&f.content, Some(MediaFileContent::Movie { movie_entry_id: id }) if *id == movie_entry_id)
+                })
+                .cloned()
+                .collect())
+        }
+
+        async fn find_by_episode_id(&self, episode_id: Uuid) -> Result<Vec<MediaFile>, DbErr> {
+            use crate::models::domain::MediaFileContent;
+            Ok(self
+                .files
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|f| {
+                    matches!(&f.content, Some(MediaFileContent::Episode { episode_id: id }) if *id == episode_id)
+                })
+                .cloned()
+                .collect())
+        }
+
+        async fn create(&self, create: CreateMediaFile) -> Result<MediaFile, DbErr> {
+            let file = MediaFile {
+                id: Uuid::new_v4(),
+                library_id: create.library_id,
+                path: create.path,
+                hash: create.hash,
+                size_bytes: create.size_bytes,
+                mime_type: create.mime_type,
+                duration: create.duration,
+                container_format: create.container_format,
+                content: create.content,
+                status: create.status,
+                scanned_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            };
+            self.files.lock().unwrap().insert(file.id, file.clone());
+            Ok(file)
+        }
+
+        async fn update(&self, update: UpdateMediaFile) -> Result<MediaFile, DbErr> {
+            let mut files = self.files.lock().unwrap();
+            let file = files
+                .get_mut(&update.id)
+                .ok_or(DbErr::RecordNotFound(format!(
+                    "File {} not found",
+                    update.id
+                )))?;
+            if let Some(status) = update.status {
+                file.status = status;
+            }
+            Ok(file.clone())
+        }
+
+        async fn delete(&self, id: Uuid) -> Result<(), DbErr> {
+            self.files.lock().unwrap().remove(&id);
+            Ok(())
+        }
+
+        async fn delete_by_ids(&self, ids: Vec<Uuid>) -> Result<u64, DbErr> {
+            let mut files = self.files.lock().unwrap();
+            let mut count = 0u64;
+            for id in ids {
+                if files.remove(&id).is_some() {
+                    count += 1;
+                }
+            }
+            Ok(count)
+        }
+    }
+}

--- a/beam-index/src/repositories/library.rs
+++ b/beam-index/src/repositories/library.rs
@@ -121,3 +121,83 @@ impl LibraryRepository for SqlLibraryRepository {
         Ok(())
     }
 }
+
+/// In-memory implementation for use in tests and test-utils consumers.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod in_memory {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    pub struct InMemoryLibraryRepository {
+        pub libraries: Mutex<HashMap<Uuid, Library>>,
+        pub file_counts: Mutex<HashMap<Uuid, u64>>,
+    }
+
+    #[async_trait]
+    impl LibraryRepository for InMemoryLibraryRepository {
+        async fn find_all(&self) -> Result<Vec<Library>, DbErr> {
+            Ok(self.libraries.lock().unwrap().values().cloned().collect())
+        }
+
+        async fn find_by_id(&self, id: Uuid) -> Result<Option<Library>, DbErr> {
+            Ok(self.libraries.lock().unwrap().get(&id).cloned())
+        }
+
+        async fn create(&self, create: CreateLibrary) -> Result<Library, DbErr> {
+            let library = Library {
+                id: Uuid::new_v4(),
+                name: create.name,
+                root_path: create.root_path,
+                description: create.description,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                last_scan_started_at: None,
+                last_scan_finished_at: None,
+                last_scan_file_count: None,
+            };
+            self.libraries
+                .lock()
+                .unwrap()
+                .insert(library.id, library.clone());
+            Ok(library)
+        }
+
+        async fn count_files(&self, library_id: Uuid) -> Result<u64, DbErr> {
+            Ok(*self
+                .file_counts
+                .lock()
+                .unwrap()
+                .get(&library_id)
+                .unwrap_or(&0))
+        }
+
+        async fn update_scan_progress(
+            &self,
+            library_id: Uuid,
+            started_at: Option<DateTime<Utc>>,
+            finished_at: Option<DateTime<Utc>>,
+            file_count: Option<i32>,
+        ) -> Result<(), DbErr> {
+            let mut libraries = self.libraries.lock().unwrap();
+            if let Some(lib) = libraries.get_mut(&library_id) {
+                if started_at.is_some() {
+                    lib.last_scan_started_at = started_at;
+                }
+                if finished_at.is_some() {
+                    lib.last_scan_finished_at = finished_at;
+                }
+                if file_count.is_some() {
+                    lib.last_scan_file_count = file_count;
+                }
+            }
+            Ok(())
+        }
+
+        async fn delete(&self, id: Uuid) -> Result<(), DbErr> {
+            self.libraries.lock().unwrap().remove(&id);
+            Ok(())
+        }
+    }
+}

--- a/beam-index/src/repositories/movie.rs
+++ b/beam-index/src/repositories/movie.rs
@@ -140,3 +140,93 @@ impl MovieRepository for SqlMovieRepository {
         Ok(())
     }
 }
+
+/// In-memory implementation for use in tests and test-utils consumers.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod in_memory {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    pub struct InMemoryMovieRepository {
+        pub movies: Mutex<HashMap<Uuid, Movie>>,
+        pub entries: Mutex<HashMap<Uuid, MovieEntry>>,
+    }
+
+    #[async_trait]
+    impl MovieRepository for InMemoryMovieRepository {
+        async fn find_by_id(&self, id: Uuid) -> Result<Option<Movie>, DbErr> {
+            Ok(self.movies.lock().unwrap().get(&id).cloned())
+        }
+
+        async fn find_by_title(&self, title: &str) -> Result<Option<Movie>, DbErr> {
+            Ok(self
+                .movies
+                .lock()
+                .unwrap()
+                .values()
+                .find(|m| m.title == title)
+                .cloned())
+        }
+
+        async fn find_all(&self) -> Result<Vec<Movie>, DbErr> {
+            Ok(self.movies.lock().unwrap().values().cloned().collect())
+        }
+
+        async fn create(&self, create: CreateMovie) -> Result<Movie, DbErr> {
+            let movie = Movie {
+                id: Uuid::new_v4(),
+                title: create.title,
+                title_localized: None,
+                description: None,
+                year: None,
+                release_date: None,
+                runtime: create.runtime,
+                poster_url: None,
+                backdrop_url: None,
+                tmdb_id: None,
+                imdb_id: None,
+                tvdb_id: None,
+                rating_tmdb: None,
+                rating_imdb: None,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            };
+            self.movies.lock().unwrap().insert(movie.id, movie.clone());
+            Ok(movie)
+        }
+
+        async fn create_entry(&self, create: CreateMovieEntry) -> Result<MovieEntry, DbErr> {
+            let entry = MovieEntry {
+                id: Uuid::new_v4(),
+                library_id: create.library_id,
+                movie_id: create.movie_id,
+                edition: create.edition,
+                is_primary: create.is_primary,
+                created_at: chrono::Utc::now(),
+            };
+            self.entries.lock().unwrap().insert(entry.id, entry.clone());
+            Ok(entry)
+        }
+
+        async fn find_entries_by_movie_id(&self, movie_id: Uuid) -> Result<Vec<MovieEntry>, DbErr> {
+            Ok(self
+                .entries
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|e| e.movie_id == movie_id)
+                .cloned()
+                .collect())
+        }
+
+        async fn ensure_library_association(
+            &self,
+            _library_id: Uuid,
+            _movie_id: Uuid,
+        ) -> Result<(), DbErr> {
+            Ok(())
+        }
+    }
+}

--- a/beam-index/src/repositories/show.rs
+++ b/beam-index/src/repositories/show.rs
@@ -191,3 +191,133 @@ impl ShowRepository for SqlShowRepository {
         Ok(Episode::from(result))
     }
 }
+
+/// In-memory implementation for use in tests and test-utils consumers.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod in_memory {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    pub struct InMemoryShowRepository {
+        pub shows: Mutex<HashMap<Uuid, Show>>,
+        pub seasons: Mutex<HashMap<Uuid, Season>>,
+        pub episodes: Mutex<HashMap<Uuid, Episode>>,
+    }
+
+    #[async_trait]
+    impl ShowRepository for InMemoryShowRepository {
+        async fn find_by_id(&self, id: Uuid) -> Result<Option<Show>, DbErr> {
+            Ok(self.shows.lock().unwrap().get(&id).cloned())
+        }
+
+        async fn find_by_title(&self, title: &str) -> Result<Option<Show>, DbErr> {
+            Ok(self
+                .shows
+                .lock()
+                .unwrap()
+                .values()
+                .find(|s| s.title == title)
+                .cloned())
+        }
+
+        async fn find_all(&self) -> Result<Vec<Show>, DbErr> {
+            Ok(self.shows.lock().unwrap().values().cloned().collect())
+        }
+
+        async fn create(&self, title: String) -> Result<Show, DbErr> {
+            let show = Show {
+                id: Uuid::new_v4(),
+                title,
+                title_localized: None,
+                description: None,
+                year: None,
+                poster_url: None,
+                backdrop_url: None,
+                tmdb_id: None,
+                imdb_id: None,
+                tvdb_id: None,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            };
+            self.shows.lock().unwrap().insert(show.id, show.clone());
+            Ok(show)
+        }
+
+        async fn ensure_library_association(
+            &self,
+            _library_id: Uuid,
+            _show_id: Uuid,
+        ) -> Result<(), DbErr> {
+            Ok(())
+        }
+
+        async fn find_or_create_season(
+            &self,
+            show_id: Uuid,
+            season_number: u32,
+        ) -> Result<Season, DbErr> {
+            {
+                let guard = self.seasons.lock().unwrap();
+                if let Some(s) = guard
+                    .values()
+                    .find(|s| s.show_id == show_id && s.season_number == season_number)
+                {
+                    return Ok(s.clone());
+                }
+            }
+            let season = Season {
+                id: Uuid::new_v4(),
+                show_id,
+                season_number,
+                poster_url: None,
+                first_aired: None,
+                last_aired: None,
+            };
+            self.seasons
+                .lock()
+                .unwrap()
+                .insert(season.id, season.clone());
+            Ok(season)
+        }
+
+        async fn find_seasons_by_show_id(&self, show_id: Uuid) -> Result<Vec<Season>, DbErr> {
+            Ok(self
+                .seasons
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|s| s.show_id == show_id)
+                .cloned()
+                .collect())
+        }
+
+        async fn find_episodes_by_season_id(&self, season_id: Uuid) -> Result<Vec<Episode>, DbErr> {
+            Ok(self
+                .episodes
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|e| e.season_id == season_id)
+                .cloned()
+                .collect())
+        }
+
+        async fn create_episode(&self, create: CreateEpisode) -> Result<Episode, DbErr> {
+            let ep = Episode {
+                id: Uuid::new_v4(),
+                season_id: create.season_id,
+                episode_number: create.episode_number,
+                title: create.title,
+                description: None,
+                air_date: None,
+                runtime: create.runtime,
+                thumbnail_url: None,
+                created_at: chrono::Utc::now(),
+            };
+            self.episodes.lock().unwrap().insert(ep.id, ep.clone());
+            Ok(ep)
+        }
+    }
+}

--- a/beam-index/src/repositories/stream.rs
+++ b/beam-index/src/repositories/stream.rs
@@ -148,3 +148,50 @@ impl MediaStreamRepository for SqlMediaStreamRepository {
         Ok(models.into_iter().map(MediaStream::from).collect())
     }
 }
+
+/// In-memory implementation for use in tests and test-utils consumers.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod in_memory {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    pub struct InMemoryMediaStreamRepository {
+        pub streams: Mutex<HashMap<Uuid, Vec<MediaStream>>>,
+    }
+
+    #[async_trait]
+    impl MediaStreamRepository for InMemoryMediaStreamRepository {
+        async fn insert_streams(&self, streams: Vec<CreateMediaStream>) -> Result<u32, DbErr> {
+            let count = streams.len() as u32;
+            for create in streams {
+                let stream = MediaStream {
+                    id: Uuid::new_v4(),
+                    file_id: create.file_id,
+                    index: create.index,
+                    stream_type: create.stream_type,
+                    codec: create.codec,
+                    metadata: create.metadata,
+                };
+                self.streams
+                    .lock()
+                    .unwrap()
+                    .entry(create.file_id)
+                    .or_default()
+                    .push(stream);
+            }
+            Ok(count)
+        }
+
+        async fn find_by_file_id(&self, file_id: Uuid) -> Result<Vec<MediaStream>, DbErr> {
+            Ok(self
+                .streams
+                .lock()
+                .unwrap()
+                .get(&file_id)
+                .cloned()
+                .unwrap_or_default())
+        }
+    }
+}

--- a/beam-stream/Cargo.toml
+++ b/beam-stream/Cargo.toml
@@ -66,4 +66,4 @@ beam-index = { path = "../beam-index", features = ["test-utils"] }
 mockall = "0.14.0"
 
 [features]
-test-utils = []
+test-utils = ["beam-index/test-utils"]


### PR DESCRIPTION
## Summary

- Moves `InMemoryMovieRepository`, `InMemoryShowRepository`, `InMemoryFileRepository`, and `InMemoryMediaStreamRepository` from the private `metadata_tests.rs` module into `pub mod in_memory` blocks within their respective `beam-index` repository files, gated by `#[cfg(any(test, feature = "test-utils"))]`
- Adds new `InMemoryLibraryRepository` to `beam-index/src/repositories/library.rs` with full implementations of `count_files` (via a seedable `file_counts` map) and `update_scan_progress` (mutates in-memory library state)
- Updates `beam-stream/Cargo.toml` so `test-utils = ["beam-index/test-utils"]` — enabling `beam-stream/test-utils` in a downstream crate gives access to all fakes
- Removes ~250 lines of duplicate definitions from `metadata_tests.rs`, replacing them with imports from the canonical locations

## Test plan

- [x] `cargo test --workspace` passes (all 22 tests green, including all 12 metadata tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] In-memory fakes are importable via `beam_stream::repositories::{movie,show,file,stream,library}::in_memory::*` in downstream test code