### PR TITLE
feat(web): add React error boundaries and fix inline Apollo errors

### DIFF
--- a/beam-web/src/components/RouteError.tsx
+++ b/beam-web/src/components/RouteError.tsx
@@ -1,0 +1,42 @@
+import { useRouter } from "@tanstack/react-router";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function RouteError({
+	error,
+	reset,
+}: {
+	error: Error;
+	reset: () => void;
+}) {
+	const router = useRouter();
+
+	const handleRetry = () => {
+		reset();
+		router.invalidate();
+	};
+
+	return (
+		<div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 flex items-center justify-center">
+			<div className="text-center space-y-4">
+				<AlertTriangle className="mx-auto text-amber-400" size={40} />
+				<h2 className="text-xl font-semibold text-white">
+					Something went wrong
+				</h2>
+				{import.meta.env.DEV && (
+					<p className="text-red-400 text-sm max-w-md mx-auto font-mono bg-gray-900/60 rounded p-3">
+						{error.message}
+					</p>
+				)}
+				<Button
+					onClick={handleRetry}
+					variant="outline"
+					className="border-gray-600 text-gray-300 hover:bg-gray-800"
+				>
+					<RefreshCw size={16} className="mr-2" />
+					Try again
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/beam-web/src/routes/__root.tsx
+++ b/beam-web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import Header from "../components/Header";
+import { RouteError } from "../components/RouteError";
 import type { AuthContextType } from "../hooks/auth";
 import TanStackQueryDevtools from "../integrations/tanstack-query/devtools";
 
@@ -14,6 +15,7 @@ interface MyRouterContext {
 }
 
 export const Route = createRootRouteWithContext<MyRouterContext>()({
+	errorComponent: RouteError,
 	component: () => (
 		<>
 			<Header />

--- a/beam-web/src/routes/admin.tsx
+++ b/beam-web/src/routes/admin.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { RouteError } from "../components/RouteError";
 import { useAuth } from "../hooks/auth";
 
 const GET_ADMIN_LOGS = gql`
@@ -51,6 +52,7 @@ export const Route = createFileRoute("/admin")({
 			throw redirect({ to: "/" });
 		}
 	},
+	errorComponent: RouteError,
 	component: AdminPage,
 });
 

--- a/beam-web/src/routes/libraries.$id.tsx
+++ b/beam-web/src/routes/libraries.$id.tsx
@@ -22,6 +22,7 @@ import {
 import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { RouteError } from "../components/RouteError";
 import type { LibraryFile, MutationRoot, QueryRoot } from "../gql";
 import { FileContentType, FileIndexStatus } from "../gql";
 
@@ -59,6 +60,7 @@ const SCAN_LIBRARY = gql`
 `;
 
 export const Route = createFileRoute("/libraries/$id")({
+	errorComponent: RouteError,
 	component: LibraryDetailPage,
 });
 
@@ -193,6 +195,7 @@ function LibraryDetailPage() {
 	const [scanLibrary] = useMutation<MutationRoot, { id: string }>(SCAN_LIBRARY);
 
 	const [scanning, setScanning] = useState(false);
+	const [scanError, setScanError] = useState<string | null>(null);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [statusFilter, setStatusFilter] = useState<FileIndexStatus | "all">(
 		"all",
@@ -201,12 +204,13 @@ function LibraryDetailPage() {
 	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 
 	const handleScan = async () => {
+		setScanError(null);
 		setScanning(true);
 		try {
 			await scanLibrary({ variables: { id } });
 			refetch();
 		} catch (err) {
-			console.error(err);
+			setScanError(err instanceof Error ? err.message : "Scan failed");
 		} finally {
 			setScanning(false);
 		}
@@ -287,57 +291,10 @@ function LibraryDetailPage() {
 		return { known, changed, unknown, totalSize };
 	}, [files]);
 
-	if (loading) {
-		return (
-			<div className="min-h-screen bg-linear-to-br from-gray-950 via-gray-900 to-gray-950 flex items-center justify-center">
-				<div className="flex items-center gap-3 text-gray-400">
-					<RefreshCw className="animate-spin" size={20} />
-					<span className="text-lg">Loading library...</span>
-				</div>
-			</div>
-		);
-	}
-
-	if (error) {
-		return (
-			<div className="min-h-screen bg-linear-to-br from-gray-950 via-gray-900 to-gray-950 flex items-center justify-center">
-				<div className="text-center space-y-4">
-					<p className="text-red-400 text-lg">Error: {error.message}</p>
-					<Link to="/libraries">
-						<Button
-							variant="outline"
-							className="border-gray-600 text-gray-300 hover:bg-gray-800"
-						>
-							Back to Libraries
-						</Button>
-					</Link>
-				</div>
-			</div>
-		);
-	}
-
-	if (!library) {
-		return (
-			<div className="min-h-screen bg-linear-to-br from-gray-950 via-gray-900 to-gray-950 flex items-center justify-center">
-				<div className="text-center space-y-4">
-					<p className="text-gray-400 text-lg">Library not found</p>
-					<Link to="/libraries">
-						<Button
-							variant="outline"
-							className="border-gray-600 text-gray-300 hover:bg-gray-800"
-						>
-							Back to Libraries
-						</Button>
-					</Link>
-				</div>
-			</div>
-		);
-	}
-
 	return (
 		<div className="min-h-screen bg-linear-to-br from-gray-950 via-gray-900 to-gray-950">
 			<div className="max-w-7xl mx-auto px-6 py-8">
-				{/* Breadcrumb & Header */}
+				{/* Breadcrumb & Header — always visible */}
 				<div className="mb-6">
 					<Link
 						to="/libraries"
@@ -348,195 +305,260 @@ function LibraryDetailPage() {
 					</Link>
 					<div className="flex items-center justify-between">
 						<div>
-							<h1 className="text-3xl font-bold text-white">{library.name}</h1>
-							{library.description && (
+							{loading ? (
+								<div className="h-9 w-48 bg-gray-700/40 rounded animate-pulse" />
+							) : (
+								<h1 className="text-3xl font-bold text-white">
+									{library?.name ?? (error ? "Library" : "Library not found")}
+								</h1>
+							)}
+							{!loading && !error && library?.description && (
 								<p className="text-gray-400 mt-1">{library.description}</p>
 							)}
 						</div>
-						<div className="flex gap-3">
-							<Button
-								onClick={() => refetch()}
-								variant="outline"
-								className="border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
-							>
-								<RefreshCw size={16} className="mr-2" />
-								Refresh
-							</Button>
-							<Button
-								onClick={handleScan}
-								disabled={scanning}
-								className="bg-cyan-600 hover:bg-cyan-700 text-white"
-							>
-								{scanning ? (
-									<RefreshCw size={16} className="animate-spin mr-2" />
-								) : (
-									<Scan size={16} className="mr-2" />
-								)}
-								{scanning ? "Scanning..." : "Scan Library"}
-							</Button>
-						</div>
-					</div>
-				</div>
-
-				{/* Stats Cards */}
-				<div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-					<div className="rounded-xl bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 p-4">
-						<div className="flex items-center gap-2 text-gray-400 text-sm mb-1">
-							<FileVideo size={14} />
-							Total Files
-						</div>
-						<div className="text-2xl font-bold text-white">{files.length}</div>
-					</div>
-					<div className="rounded-xl bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 p-4">
-						<div className="flex items-center gap-2 text-emerald-400 text-sm mb-1">
-							<CheckCircle2 size={14} />
-							Indexed
-						</div>
-						<div className="text-2xl font-bold text-white">{stats.known}</div>
-					</div>
-					<div className="rounded-xl bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 p-4">
-						<div className="flex items-center gap-2 text-amber-400 text-sm mb-1">
-							<AlertTriangle size={14} />
-							Changed / Unknown
-						</div>
-						<div className="text-2xl font-bold text-white">
-							{stats.changed + stats.unknown}
-						</div>
-					</div>
-					<div className="rounded-xl bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 p-4">
-						<div className="flex items-center gap-2 text-gray-400 text-sm mb-1">
-							<HardDrive size={14} />
-							Total Size
-						</div>
-						<div className="text-2xl font-bold text-white">
-							{formatFileSize(stats.totalSize)}
-						</div>
-					</div>
-				</div>
-
-				{/* Scan Info */}
-				{library.lastScanFinishedAt && (
-					<div className="flex items-center gap-4 text-sm text-gray-400 mb-6 px-1">
-						<span className="flex items-center gap-1.5">
-							<Clock size={14} />
-							Last scanned {formatTimeAgo(library.lastScanFinishedAt)}
-						</span>
-						{library.lastScanFileCount != null && (
-							<span>• {library.lastScanFileCount} files processed</span>
-						)}
-					</div>
-				)}
-
-				{/* Search & Filter Bar */}
-				<div className="flex flex-col sm:flex-row gap-3 mb-6">
-					<div className="relative flex-1">
-						<Search
-							size={16}
-							className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500"
-						/>
-						<Input
-							placeholder="Search files by path, type, or format..."
-							value={searchQuery}
-							onChange={(e) => setSearchQuery(e.target.value)}
-							className="pl-10 bg-gray-800/60 border-gray-700 text-white placeholder-gray-500 focus:border-cyan-500"
-						/>
-					</div>
-					<div className="flex items-center gap-2">
-						<Filter size={16} className="text-gray-500" />
-						<div className="flex rounded-lg border border-gray-700 overflow-hidden">
-							{(
-								[
-									{ label: "All", value: "all" },
-									{ label: "Indexed", value: FileIndexStatus.Known },
-									{ label: "Changed", value: FileIndexStatus.Changed },
-									{ label: "Unknown", value: FileIndexStatus.Unknown },
-								] as const
-							).map((opt) => (
-								<button
-									key={opt.value}
-									type="button"
-									onClick={() => setStatusFilter(opt.value)}
-									className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-										statusFilter === opt.value
-											? "bg-cyan-600 text-white"
-											: "bg-gray-800/60 text-gray-400 hover:bg-gray-700 hover:text-white"
-									}`}
+						<div className="flex flex-col items-end gap-2">
+							<div className="flex gap-3">
+								<Button
+									onClick={() => refetch()}
+									variant="outline"
+									className="border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
 								>
-									{opt.label}
-								</button>
+									<RefreshCw size={16} className="mr-2" />
+									Refresh
+								</Button>
+								<Button
+									onClick={handleScan}
+									disabled={scanning || loading || !!error || !library}
+									className="bg-cyan-600 hover:bg-cyan-700 text-white"
+								>
+									{scanning ? (
+										<RefreshCw size={16} className="animate-spin mr-2" />
+									) : (
+										<Scan size={16} className="mr-2" />
+									)}
+									{scanning ? "Scanning..." : "Scan Library"}
+								</Button>
+							</div>
+							{scanError && (
+								<p className="text-red-400 text-sm">Scan failed: {scanError}</p>
+							)}
+						</div>
+					</div>
+				</div>
+
+				{/* Body — conditional on loading/error/not-found */}
+				{loading ? (
+					<>
+						{/* Skeleton stats cards */}
+						<div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+							{[...Array(4)].map((_, i) => (
+								<div
+									// biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no identity
+									key={i}
+									className="rounded-xl bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 p-4 animate-pulse"
+								>
+									<div className="h-4 bg-gray-700/50 rounded mb-3 w-24" />
+									<div className="h-8 bg-gray-700/50 rounded w-12" />
+								</div>
 							))}
 						</div>
+						{/* Skeleton table */}
+						<div className="rounded-xl border border-gray-700/50 overflow-hidden animate-pulse">
+							<div className="h-10 bg-gray-800/60 border-b border-gray-700/50" />
+							{[...Array(5)].map((_, i) => (
+								<div
+									// biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no identity
+									key={i}
+									className="h-12 border-b border-gray-800/50 bg-gray-800/20"
+								/>
+							))}
+						</div>
+					</>
+				) : error ? (
+					<div className="text-center py-12 space-y-4">
+						<p className="text-red-400 text-lg">Error: {error.message}</p>
+						<Button
+							onClick={() => refetch()}
+							variant="outline"
+							className="border-gray-600 text-gray-300 hover:bg-gray-800"
+						>
+							Retry
+						</Button>
 					</div>
-				</div>
-
-				{/* File Table */}
-				{filteredFiles.length === 0 ? (
-					<div className="text-center py-16 rounded-xl border border-dashed border-gray-700 bg-gray-800/20">
-						<FileQuestion className="mx-auto text-gray-600 mb-4" size={48} />
-						<h3 className="text-lg font-semibold text-gray-400 mb-2">
-							{files.length === 0
-								? "No files indexed"
-								: "No files match your filters"}
-						</h3>
-						<p className="text-gray-500">
-							{files.length === 0
-								? "Run a scan to index files in this library."
-								: "Try adjusting your search or filter criteria."}
-						</p>
+				) : !library ? (
+					<div className="text-center py-12">
+						<p className="text-gray-400 text-lg">Library not found</p>
 					</div>
 				) : (
-					<div className="rounded-xl border border-gray-700/50 overflow-hidden">
-						{/* Table Header */}
-						<div className="grid grid-cols-[1fr_100px_80px_100px_100px] gap-4 px-5 py-3 bg-gray-800/60 border-b border-gray-700/50">
-							<SortHeader
-								label="File Path"
-								field="path"
-								currentField={sortField}
-								currentDirection={sortDirection}
-								onSort={handleSort}
-							/>
-							<SortHeader
-								label="Size"
-								field="sizeBytes"
-								currentField={sortField}
-								currentDirection={sortDirection}
-								onSort={handleSort}
-							/>
-							<SortHeader
-								label="Status"
-								field="status"
-								currentField={sortField}
-								currentDirection={sortDirection}
-								onSort={handleSort}
-							/>
-							<SortHeader
-								label="Content"
-								field="contentType"
-								currentField={sortField}
-								currentDirection={sortDirection}
-								onSort={handleSort}
-							/>
-							<SortHeader
-								label="Updated"
-								field="updatedAt"
-								currentField={sortField}
-								currentDirection={sortDirection}
-								onSort={handleSort}
-							/>
+					<>
+						{/* Stats Cards */}
+						<div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+							<div className="rounded-xl bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 p-4">
+								<div className="flex items-center gap-2 text-gray-400 text-sm mb-1">
+									<FileVideo size={14} />
+									Total Files
+								</div>
+								<div className="text-2xl font-bold text-white">
+									{files.length}
+								</div>
+							</div>
+							<div className="rounded-xl bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 p-4">
+								<div className="flex items-center gap-2 text-emerald-400 text-sm mb-1">
+									<CheckCircle2 size={14} />
+									Indexed
+								</div>
+								<div className="text-2xl font-bold text-white">
+									{stats.known}
+								</div>
+							</div>
+							<div className="rounded-xl bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 p-4">
+								<div className="flex items-center gap-2 text-amber-400 text-sm mb-1">
+									<AlertTriangle size={14} />
+									Changed / Unknown
+								</div>
+								<div className="text-2xl font-bold text-white">
+									{stats.changed + stats.unknown}
+								</div>
+							</div>
+							<div className="rounded-xl bg-gray-800/40 backdrop-blur-sm border border-gray-700/50 p-4">
+								<div className="flex items-center gap-2 text-gray-400 text-sm mb-1">
+									<HardDrive size={14} />
+									Total Size
+								</div>
+								<div className="text-2xl font-bold text-white">
+									{formatFileSize(stats.totalSize)}
+								</div>
+							</div>
 						</div>
 
-						{/* Table Body */}
-						<div className="divide-y divide-gray-800/50">
-							{filteredFiles.map((file) => (
-								<FileRow key={file.id} file={file} />
-							))}
+						{/* Scan Info */}
+						{library.lastScanFinishedAt && (
+							<div className="flex items-center gap-4 text-sm text-gray-400 mb-6 px-1">
+								<span className="flex items-center gap-1.5">
+									<Clock size={14} />
+									Last scanned {formatTimeAgo(library.lastScanFinishedAt)}
+								</span>
+								{library.lastScanFileCount != null && (
+									<span>• {library.lastScanFileCount} files processed</span>
+								)}
+							</div>
+						)}
+
+						{/* Search & Filter Bar */}
+						<div className="flex flex-col sm:flex-row gap-3 mb-6">
+							<div className="relative flex-1">
+								<Search
+									size={16}
+									className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500"
+								/>
+								<Input
+									placeholder="Search files by path, type, or format..."
+									value={searchQuery}
+									onChange={(e) => setSearchQuery(e.target.value)}
+									className="pl-10 bg-gray-800/60 border-gray-700 text-white placeholder-gray-500 focus:border-cyan-500"
+								/>
+							</div>
+							<div className="flex items-center gap-2">
+								<Filter size={16} className="text-gray-500" />
+								<div className="flex rounded-lg border border-gray-700 overflow-hidden">
+									{(
+										[
+											{ label: "All", value: "all" },
+											{ label: "Indexed", value: FileIndexStatus.Known },
+											{ label: "Changed", value: FileIndexStatus.Changed },
+											{ label: "Unknown", value: FileIndexStatus.Unknown },
+										] as const
+									).map((opt) => (
+										<button
+											key={opt.value}
+											type="button"
+											onClick={() => setStatusFilter(opt.value)}
+											className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+												statusFilter === opt.value
+													? "bg-cyan-600 text-white"
+													: "bg-gray-800/60 text-gray-400 hover:bg-gray-700 hover:text-white"
+											}`}
+										>
+											{opt.label}
+										</button>
+									))}
+								</div>
+							</div>
 						</div>
 
-						{/* Footer */}
-						<div className="px-5 py-3 bg-gray-800/40 border-t border-gray-700/50 text-xs text-gray-500">
-							Showing {filteredFiles.length} of {files.length} files
-						</div>
-					</div>
+						{/* File Table */}
+						{filteredFiles.length === 0 ? (
+							<div className="text-center py-16 rounded-xl border border-dashed border-gray-700 bg-gray-800/20">
+								<FileQuestion
+									className="mx-auto text-gray-600 mb-4"
+									size={48}
+								/>
+								<h3 className="text-lg font-semibold text-gray-400 mb-2">
+									{files.length === 0
+										? "No files indexed"
+										: "No files match your filters"}
+								</h3>
+								<p className="text-gray-500">
+									{files.length === 0
+										? "Run a scan to index files in this library."
+										: "Try adjusting your search or filter criteria."}
+								</p>
+							</div>
+						) : (
+							<div className="rounded-xl border border-gray-700/50 overflow-hidden">
+								{/* Table Header */}
+								<div className="grid grid-cols-[1fr_100px_80px_100px_100px] gap-4 px-5 py-3 bg-gray-800/60 border-b border-gray-700/50">
+									<SortHeader
+										label="File Path"
+										field="path"
+										currentField={sortField}
+										currentDirection={sortDirection}
+										onSort={handleSort}
+									/>
+									<SortHeader
+										label="Size"
+										field="sizeBytes"
+										currentField={sortField}
+										currentDirection={sortDirection}
+										onSort={handleSort}
+									/>
+									<SortHeader
+										label="Status"
+										field="status"
+										currentField={sortField}
+										currentDirection={sortDirection}
+										onSort={handleSort}
+									/>
+									<SortHeader
+										label="Content"
+										field="contentType"
+										currentField={sortField}
+										currentDirection={sortDirection}
+										onSort={handleSort}
+									/>
+									<SortHeader
+										label="Updated"
+										field="updatedAt"
+										currentField={sortField}
+										currentDirection={sortDirection}
+										onSort={handleSort}
+									/>
+								</div>
+
+								{/* Table Body */}
+								<div className="divide-y divide-gray-800/50">
+									{filteredFiles.map((file) => (
+										<FileRow key={file.id} file={file} />
+									))}
+								</div>
+
+								{/* Footer */}
+								<div className="px-5 py-3 bg-gray-800/40 border-t border-gray-700/50 text-xs text-gray-500">
+									Showing {filteredFiles.length} of {files.length} files
+								</div>
+							</div>
+						)}
+					</>
 				)}
 			</div>
 		</div>

--- a/beam-web/src/routes/libraries.tsx
+++ b/beam-web/src/routes/libraries.tsx
@@ -16,6 +16,7 @@ import { useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RouteError } from "../components/RouteError";
 import type { Library, MutationRoot, QueryRoot } from "../gql";
 
 const GET_LIBRARIES = gql`
@@ -59,6 +60,7 @@ const DELETE_LIBRARY = gql`
 `;
 
 export const Route = createFileRoute("/libraries")({
+	errorComponent: RouteError,
 	component: LibrariesPage,
 });
 
@@ -113,10 +115,10 @@ function ScanStatusBadge({ library }: { library: Library }) {
 
 function LibrariesPage() {
 	const { data, loading, error, refetch } = useQuery<QueryRoot>(GET_LIBRARIES);
-	const [createLibrary, { loading: creating }] = useMutation<
-		MutationRoot,
-		{ name: string; rootPath: string }
-	>(CREATE_LIBRARY);
+	const [createLibrary, { loading: creating, error: createError }] =
+		useMutation<MutationRoot, { name: string; rootPath: string }>(
+			CREATE_LIBRARY,
+		);
 	const [scanLibrary] = useMutation<MutationRoot, { id: string }>(SCAN_LIBRARY);
 	const [deleteLibrary] = useMutation<MutationRoot, { id: string }>(
 		DELETE_LIBRARY,
@@ -128,6 +130,8 @@ function LibrariesPage() {
 	const libNameId = useId();
 	const libRootPathId = useId();
 	const [scanningIds, setScanningIds] = useState<Set<string>>(new Set());
+	const [scanErrors, setScanErrors] = useState<Record<string, string>>({});
+	const [deleteErrors, setDeleteErrors] = useState<Record<string, string>>({});
 
 	const handleCreate = async (e: React.FormEvent) => {
 		e.preventDefault();
@@ -137,18 +141,26 @@ function LibrariesPage() {
 			setName("");
 			setRootPath("");
 			setShowCreateForm(false);
-		} catch (err) {
-			console.error(err);
+		} catch {
+			// createError from the hook surfaces the error in the form
 		}
 	};
 
 	const handleScan = async (libraryId: string) => {
+		setScanErrors((prev) => {
+			const next = { ...prev };
+			delete next[libraryId];
+			return next;
+		});
 		setScanningIds((prev) => new Set(prev).add(libraryId));
 		try {
 			await scanLibrary({ variables: { id: libraryId } });
 			refetch();
 		} catch (err) {
-			console.error(err);
+			setScanErrors((prev) => ({
+				...prev,
+				[libraryId]: err instanceof Error ? err.message : "Scan failed",
+			}));
 		} finally {
 			setScanningIds((prev) => {
 				const next = new Set(prev);
@@ -166,41 +178,21 @@ function LibrariesPage() {
 		) {
 			return;
 		}
+		setDeleteErrors((prev) => {
+			const next = { ...prev };
+			delete next[libraryId];
+			return next;
+		});
 		try {
 			await deleteLibrary({ variables: { id: libraryId } });
 			refetch();
 		} catch (err) {
-			console.error(err);
+			setDeleteErrors((prev) => ({
+				...prev,
+				[libraryId]: err instanceof Error ? err.message : "Delete failed",
+			}));
 		}
 	};
-
-	if (loading) {
-		return (
-			<div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 flex items-center justify-center">
-				<div className="flex items-center gap-3 text-gray-400">
-					<RefreshCw className="animate-spin" size={20} />
-					<span className="text-lg">Loading libraries...</span>
-				</div>
-			</div>
-		);
-	}
-
-	if (error) {
-		return (
-			<div className="min-h-screen bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950 flex items-center justify-center">
-				<div className="text-center space-y-4">
-					<p className="text-red-400 text-lg">Error: {error.message}</p>
-					<Button
-						onClick={() => refetch()}
-						variant="outline"
-						className="border-gray-600 text-gray-300 hover:bg-gray-800"
-					>
-						Retry
-					</Button>
-				</div>
-			</div>
-		);
-	}
 
 	const libraries = data?.libraries ?? [];
 
@@ -296,11 +288,32 @@ function LibrariesPage() {
 								</Button>
 							</div>
 						</form>
+						{createError && (
+							<p className="text-red-400 text-sm mt-3">
+								Error: {createError.message}
+							</p>
+						)}
 					</div>
 				)}
 
 				{/* Libraries Grid */}
-				{libraries.length === 0 ? (
+				{loading ? (
+					<div className="flex items-center gap-3 text-gray-400 py-12">
+						<RefreshCw className="animate-spin" size={20} />
+						<span className="text-lg">Loading libraries...</span>
+					</div>
+				) : error ? (
+					<div className="text-center py-12 space-y-4">
+						<p className="text-red-400 text-lg">Error: {error.message}</p>
+						<Button
+							onClick={() => refetch()}
+							variant="outline"
+							className="border-gray-600 text-gray-300 hover:bg-gray-800"
+						>
+							Retry
+						</Button>
+					</div>
+				) : libraries.length === 0 ? (
 					<div className="text-center py-20 rounded-xl border border-dashed border-gray-700 bg-gray-800/20">
 						<FolderOpen className="mx-auto text-gray-600 mb-4" size={56} />
 						<h3 className="text-xl font-semibold text-gray-400 mb-2">
@@ -392,6 +405,18 @@ function LibrariesPage() {
 										<Trash2 size={16} />
 									</Button>
 								</div>
+
+								{/* Inline mutation errors */}
+								{scanErrors[lib.id] && (
+									<p className="px-5 pb-3 text-red-400 text-xs">
+										Scan failed: {scanErrors[lib.id]}
+									</p>
+								)}
+								{deleteErrors[lib.id] && (
+									<p className="px-5 pb-3 text-red-400 text-xs">
+										Delete failed: {deleteErrors[lib.id]}
+									</p>
+								)}
 							</div>
 						))}
 					</div>

--- a/beam-web/src/routes/media.$id.tsx
+++ b/beam-web/src/routes/media.$id.tsx
@@ -176,8 +176,10 @@ function RouteComponent() {
 		const loadVideo = async () => {
 			// 1. Exchange the user's auth token for a short-lived stream token.
 			const tokenRes = await apiClient.POST("/v1/stream/{id}/token", {
-				params: { path: { id } },
-				headers: { Authorization: `Bearer ${token}` },
+				params: {
+					path: { id },
+					header: { Authorization: `Bearer ${token}` },
+				},
 			});
 
 			if (cancelled) return;


### PR DESCRIPTION
## Summary

- Add `RouteError` component as a TanStack Router `errorComponent` fallback — shows "Something went wrong", error message in dev only, and a retry button (`reset()` + `router.invalidate()`)
- Wire `errorComponent: RouteError` to `__root`, `admin`, `libraries`, and `libraries.$id` routes (render crash → visible fallback instead of blank screen)
- Refactor `libraries.tsx`: remove full-page `loading`/`error` early returns; header (title, Add Library, Refresh) always renders; `createLibrary` error shown inline in form; per-card `scanLibrary`/`deleteLibrary` errors surfaced instead of silently dropped
- Refactor `libraries.$id.tsx`: remove full-page early returns for loading, error, and not-found states; Back-to-Libraries link always renders; library name shows skeleton/placeholder; loading shows skeleton stats cards + table; scan mutation error shown near Scan button

Closes td-7b5d30.

## Test plan

- [ ] `bun run check` passes (verified locally)
- [ ] Navigate to `/libraries` while backend is down — header remains visible, inline error shown with Retry button
- [ ] Navigate to `/libraries/:id` while backend is down — Back-to-Libraries link remains visible, inline error shown
- [ ] Trigger a failed library create — error message appears below the form
- [ ] Trigger a failed scan — per-card error message appears
- [ ] Simulate a render crash — `RouteError` fallback shown instead of blank screen